### PR TITLE
Separate palette results for shareable link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
         "core-js": "^3.6.4",
         "vue": "^2.6.11",
         "vue-class-component": "^7.2.3",
-        "vue-property-decorator": "^8.4.1"
+        "vue-property-decorator": "^8.4.1",
+        "vue-router": "^3.2.0"
       },
       "devDependencies": {
         "@types/jest": "^24.9.1",
@@ -18,6 +19,7 @@
         "@typescript-eslint/parser": "^2.26.0",
         "@vue/cli-plugin-babel": "~4.3.0",
         "@vue/cli-plugin-eslint": "~4.3.0",
+        "@vue/cli-plugin-router": "~4.5.0",
         "@vue/cli-plugin-typescript": "~4.3.0",
         "@vue/cli-plugin-unit-jest": "~4.3.0",
         "@vue/cli-service": "~4.3.0",
@@ -2149,12 +2151,12 @@
       }
     },
     "node_modules/@vue/cli-plugin-router": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@vue/cli-plugin-router/-/cli-plugin-router-4.3.1.tgz",
-      "integrity": "sha512-m0ntr5R6q62oNMODgoyHAVAd/sDtsH15GdBrScZsPNeyHxmzmNBDlsNM38yYGGY064zDRRWif15d1yaTREybrA==",
+      "version": "4.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/cli-plugin-router/-/cli-plugin-router-4.5.13.tgz",
+      "integrity": "sha512-tgtMDjchB/M1z8BcfV4jSOY9fZSMDTPgF9lsJIiqBWMxvBIsk9uIZHxp62DibYME4CCKb/nNK61XHaikFp+83w==",
       "dev": true,
       "dependencies": {
-        "@vue/cli-shared-utils": "^4.3.1"
+        "@vue/cli-shared-utils": "^4.5.13"
       },
       "peerDependencies": {
         "@vue/cli-service": "^3.0.0 || ^4.0.0-0"
@@ -2628,9 +2630,9 @@
       }
     },
     "node_modules/@vue/cli-shared-utils": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@vue/cli-shared-utils/-/cli-shared-utils-4.3.1.tgz",
-      "integrity": "sha512-lcfRalou7Z9jZgIh9PeTIpwDK7RIjr9OxfLGwbdR8czUZYUeUa67zVEMJD0OPYh/CCoREtzNbVfLPb/IYYxWEA==",
+      "version": "4.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/cli-shared-utils/-/cli-shared-utils-4.5.13.tgz",
+      "integrity": "sha512-HpnOrkLg42RFUsQGMJv26oTG3J3FmKtO2WSRhKIIL+1ok3w9OjGCtA3nMMXN27f9eX14TqO64M36DaiSZ1fSiw==",
       "dev": true,
       "dependencies": {
         "@hapi/joi": "^15.0.1",
@@ -2643,7 +2645,6 @@
         "ora": "^3.4.0",
         "read-pkg": "^5.1.1",
         "request": "^2.88.2",
-        "request-promise-native": "^1.0.8",
         "semver": "^6.1.0",
         "strip-ansi": "^6.0.0"
       }
@@ -17726,6 +17727,11 @@
         "vue": "*"
       }
     },
+    "node_modules/vue-router": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.5.2.tgz",
+      "integrity": "sha512-807gn82hTnjCYGrnF3eNmIw/dk7/GE4B5h69BlyCK9KHASwSloD1Sjcn06zg9fVG4fYH2DrsNBZkpLtb25WtaQ=="
+    },
     "node_modules/vue-style-loader": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-4.1.2.tgz",
@@ -20568,12 +20574,12 @@
       }
     },
     "@vue/cli-plugin-router": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@vue/cli-plugin-router/-/cli-plugin-router-4.3.1.tgz",
-      "integrity": "sha512-m0ntr5R6q62oNMODgoyHAVAd/sDtsH15GdBrScZsPNeyHxmzmNBDlsNM38yYGGY064zDRRWif15d1yaTREybrA==",
+      "version": "4.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/cli-plugin-router/-/cli-plugin-router-4.5.13.tgz",
+      "integrity": "sha512-tgtMDjchB/M1z8BcfV4jSOY9fZSMDTPgF9lsJIiqBWMxvBIsk9uIZHxp62DibYME4CCKb/nNK61XHaikFp+83w==",
       "dev": true,
       "requires": {
-        "@vue/cli-shared-utils": "^4.3.1"
+        "@vue/cli-shared-utils": "^4.5.13"
       }
     },
     "@vue/cli-plugin-typescript": {
@@ -20621,8 +20627,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@vue/cli-plugin-vuex/-/cli-plugin-vuex-4.3.1.tgz",
       "integrity": "sha512-mukwOlhZGBJhkqO2b3wHFFHjK5aP00b1WUHdrOfLR7M18euhaTyb4kA5nwZwEOmU3EzZx6kHzSFCRy/XaMkLug==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@vue/cli-service": {
       "version": "4.3.1",
@@ -20920,9 +20925,9 @@
       }
     },
     "@vue/cli-shared-utils": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@vue/cli-shared-utils/-/cli-shared-utils-4.3.1.tgz",
-      "integrity": "sha512-lcfRalou7Z9jZgIh9PeTIpwDK7RIjr9OxfLGwbdR8czUZYUeUa67zVEMJD0OPYh/CCoREtzNbVfLPb/IYYxWEA==",
+      "version": "4.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/cli-shared-utils/-/cli-shared-utils-4.5.13.tgz",
+      "integrity": "sha512-HpnOrkLg42RFUsQGMJv26oTG3J3FmKtO2WSRhKIIL+1ok3w9OjGCtA3nMMXN27f9eX14TqO64M36DaiSZ1fSiw==",
       "dev": true,
       "requires": {
         "@hapi/joi": "^15.0.1",
@@ -20935,7 +20940,6 @@
         "ora": "^3.4.0",
         "read-pkg": "^5.1.1",
         "request": "^2.88.2",
-        "request-promise-native": "^1.0.8",
         "semver": "^6.1.0",
         "strip-ansi": "^6.0.0"
       },
@@ -21020,8 +21024,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@vue/preload-webpack-plugin/-/preload-webpack-plugin-1.1.1.tgz",
       "integrity": "sha512-8VCoJeeH8tCkzhkpfOkt+abALQkS11OIHhte5MBzYaKMTqK0A3ZAKEUVAffsOklhEv7t0yrQt696Opnu9oAx+w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@vue/test-utils": {
       "version": "1.0.0-beta.31",
@@ -21269,8 +21272,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
       "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "6.2.0",
@@ -21310,15 +21312,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv-keywords": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
       "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -21684,8 +21684,7 @@
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
       "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "babel-jest": {
       "version": "24.9.0",
@@ -25750,24 +25749,28 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
+          "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25778,12 +25781,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25794,36 +25799,42 @@
         },
         "chownr": {
           "version": "1.1.4",
+          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "3.2.6",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25833,24 +25844,28 @@
         },
         "deep-extend": {
           "version": "0.6.0",
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.7",
+          "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25860,12 +25875,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25882,6 +25899,7 @@
         },
         "glob": {
           "version": "7.1.6",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25896,12 +25914,14 @@
         },
         "has-unicode": {
           "version": "2.0.1",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25911,6 +25931,7 @@
         },
         "ignore-walk": {
           "version": "3.0.3",
+          "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25920,6 +25941,7 @@
         },
         "inflight": {
           "version": "1.0.6",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25930,18 +25952,21 @@
         },
         "inherits": {
           "version": "2.0.4",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25951,12 +25976,14 @@
         },
         "isarray": {
           "version": "1.0.0",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25966,12 +25993,14 @@
         },
         "minimist": {
           "version": "1.2.5",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "minipass": {
           "version": "2.9.0",
+          "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25982,6 +26011,7 @@
         },
         "minizlib": {
           "version": "1.3.3",
+          "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25991,6 +26021,7 @@
         },
         "mkdirp": {
           "version": "0.5.3",
+          "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -26000,12 +26031,14 @@
         },
         "ms": {
           "version": "2.1.2",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.3.3",
+          "integrity": "sha512-EkY0GeSq87rWp1hoq/sH/wnTWgFVhYlnIkbJ0YJFfRgEFlz2RraCjBpFQ+vrEgEdp0ThfyHADmkChEhcb7PKyw==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -26017,6 +26050,7 @@
         },
         "node-pre-gyp": {
           "version": "0.14.0",
+          "integrity": "sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -26035,6 +26069,7 @@
         },
         "nopt": {
           "version": "4.0.3",
+          "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -26045,6 +26080,7 @@
         },
         "npm-bundled": {
           "version": "1.1.1",
+          "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -26054,12 +26090,14 @@
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
+          "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.8",
+          "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -26071,6 +26109,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -26083,18 +26122,21 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -26104,18 +26146,21 @@
         },
         "os-homedir": {
           "version": "1.0.2",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -26126,18 +26171,21 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.1",
+          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -26150,6 +26198,7 @@
         },
         "readable-stream": {
           "version": "2.3.7",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -26165,6 +26214,7 @@
         },
         "rimraf": {
           "version": "2.7.1",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -26174,42 +26224,49 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.7.1",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "string_decoder": {
           "version": "1.1.1",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -26219,6 +26276,7 @@
         },
         "string-width": {
           "version": "1.0.2",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -26230,6 +26288,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -26239,12 +26298,14 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.13",
+          "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -26260,12 +26321,14 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
+          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -26275,12 +26338,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "yallist": {
           "version": "3.1.1",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -27794,8 +27859,7 @@
           "version": "7.2.5",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.5.tgz",
           "integrity": "sha512-C34cIU4+DB2vMyAbmEKossWq2ZQDr6QEyuuCzWrM9zfw1sGc0mYiJ0UnG9zzNykt49C2Fi34hvr2vssFQRS6EA==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -27913,8 +27977,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
       "integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "24.9.0",
@@ -33186,8 +33249,7 @@
     "vue-class-component": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/vue-class-component/-/vue-class-component-7.2.3.tgz",
-      "integrity": "sha512-oEqYpXKaFN+TaXU+mRLEx8dX0ah85aAJEe61mpdoUrq0Bhe/6sWhyZX1JjMQLhVsHAkncyhedhmCdDVSasUtDw==",
-      "requires": {}
+      "integrity": "sha512-oEqYpXKaFN+TaXU+mRLEx8dX0ah85aAJEe61mpdoUrq0Bhe/6sWhyZX1JjMQLhVsHAkncyhedhmCdDVSasUtDw=="
     },
     "vue-eslint-parser": {
       "version": "7.0.0",
@@ -33267,6 +33329,11 @@
       "requires": {
         "vue-class-component": "^7.1.0"
       }
+    },
+    "vue-router": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.5.2.tgz",
+      "integrity": "sha512-807gn82hTnjCYGrnF3eNmIw/dk7/GE4B5h69BlyCK9KHASwSloD1Sjcn06zg9fVG4fYH2DrsNBZkpLtb25WtaQ=="
     },
     "vue-style-loader": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "core-js": "^3.6.4",
     "vue": "^2.6.11",
     "vue-class-component": "^7.2.3",
-    "vue-property-decorator": "^8.4.1"
+    "vue-property-decorator": "^8.4.1",
+    "vue-router": "^3.2.0"
   },
   "devDependencies": {
     "@types/jest": "^24.9.1",
@@ -20,6 +21,7 @@
     "@typescript-eslint/parser": "^2.26.0",
     "@vue/cli-plugin-babel": "~4.3.0",
     "@vue/cli-plugin-eslint": "~4.3.0",
+    "@vue/cli-plugin-router": "~4.5.0",
     "@vue/cli-plugin-typescript": "~4.3.0",
     "@vue/cli-plugin-unit-jest": "~4.3.0",
     "@vue/cli-service": "~4.3.0",
@@ -33,7 +35,7 @@
     "sass": "^1.26.3",
     "sass-loader": "^8.0.2",
     "typescript": "~3.8.3",
-    "vuetype": "^0.3.2",
-    "vue-template-compiler": "^2.6.11"
+    "vue-template-compiler": "^2.6.11",
+    "vuetype": "^0.3.2"
   }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,26 +3,3 @@
     <router-view/>
   </div>
 </template>
-
-<style lang="scss">
-#app {
-  font-family: Avenir, Helvetica, Arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  text-align: center;
-  color: #2c3e50;
-}
-
-#nav {
-  padding: 30px;
-
-  a {
-    font-weight: bold;
-    color: #2c3e50;
-
-    &.router-link-exact-active {
-      color: #42b983;
-    }
-  }
-}
-</style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,10 +1,5 @@
 <template>
   <div id="app">
-    <div id="nav">
-      <router-link to="/">Home</router-link> |
-      <router-link to="/about">About</router-link> |
-      <router-link to="/palette/red">Palette</router-link>
-    </div>
     <router-view/>
   </div>
 </template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,71 +1,32 @@
 <template>
-  <div id="app" @paste="onAppPaste">
-    <template v-if="showInitialInfo">
-      <InitialInfo v-if="showInitialInfo"/>
-    </template>
-    <ShowColors
-      v-else
-      :colors="colors"
-    />
-    <p v-if="errorMessageToShow">
-      {{ errorMessageToShow }}
-    </p>
+  <div id="app">
+    <div id="nav">
+      <router-link to="/">Home</router-link> |
+      <router-link to="/about">About</router-link>
+    </div>
+    <router-view/>
   </div>
 </template>
 
-<script lang="ts">
-import { Component, Vue } from 'vue-property-decorator';
-import InitialInfo from '@/components/InitialInfo.vue';
-import ShowColors from '@/components/ShowColors.vue';
-
-@Component({
-  components: {
-    InitialInfo,
-    ShowColors,
-  },
-})
-export default class App extends Vue {
-  private colors: string[] = [];
-
-  private errorMessageToShow = '';
-
-  public onAppPaste(pastedContent: ClipboardEvent) {
-    let str = '';
-
-    if (pastedContent.clipboardData) {
-      str = pastedContent.clipboardData.getData('text');
-      this.errorMessageToShow = '';
-    } else {
-      this.errorMessageToShow = 'Clipboard is empty, nothing was pasted!';
-    }
-
-    this.colors = this.findColors(str);
-    if (!this.colors.length) this.errorMessageToShow = 'No colors of the #RRGGBB format were found in the pasted text.';
-  }
-
-  public findColors(pastedText: string): string[] {
-    const colors = pastedText.match(/#[0-9a-fA-F]{6}/g) || [];
-    return [...new Set(
-      colors.map(color => color.toLowerCase()),
-    )];
-  }
-
-  get showInitialInfo() {
-    return !this.colors.length;
-  }
-}
-</script>
-
 <style lang="scss">
 #app {
-  align-items: center;
-  background-color: #181818;
-  color: #ffffff;
-  display: flex;
-  flex-direction: column;
-  font-family: Helvetica, Arial, sans-serif;
-  justify-content: center;
-  min-height: 100vh;
+  font-family: Avenir, Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
   text-align: center;
+  color: #2c3e50;
+}
+
+#nav {
+  padding: 30px;
+
+  a {
+    font-weight: bold;
+    color: #2c3e50;
+
+    &.router-link-exact-active {
+      color: #42b983;
+    }
+  }
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,8 @@
   <div id="app">
     <div id="nav">
       <router-link to="/">Home</router-link> |
-      <router-link to="/about">About</router-link>
+      <router-link to="/about">About</router-link> |
+      <router-link to="/palette/red">Palette</router-link>
     </div>
     <router-view/>
   </div>

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,3 +3,17 @@
     <router-view/>
   </div>
 </template>
+
+<style lang="scss">
+#app {
+  align-items: center;
+  background-color: #181818;
+  color: #ffffff;
+  display: flex;
+  flex-direction: column;
+  font-family: Helvetica, Arial, sans-serif;
+  justify-content: center;
+  min-height: 100vh;
+  text-align: center;
+}
+</style>

--- a/src/components/InitialInfo.vue
+++ b/src/components/InitialInfo.vue
@@ -29,7 +29,7 @@
     </p>
 
     <p class="initial-info__paragraph initial-info__paragraph--no-justify">
-      <strong>VLAVAAV</strong> © Alex L. Alves 2020.
+      <strong>VLAVAAV</strong> © Alex L. Alves 2021.
       <br/>
       Check the project out on GitHub:
       <a

--- a/src/components/ShowColors.vue
+++ b/src/components/ShowColors.vue
@@ -7,7 +7,7 @@
       <div
         v-for="color in colors"
         :key="color"
-        :style="`background-color: ${color}; flex-grow: 1`"
+        :style="`background-color: #${color}; flex-grow: 1`"
         @click="copyToClipboard(color)"
         class="show-colors__cell"
       >
@@ -32,7 +32,13 @@ import { Component, Prop, Vue } from 'vue-property-decorator';
 
 @Component
 export default class ShowColors extends Vue {
-  @Prop({ required: false, type: Array, default: () => [] }) readonly colors!: string[]
+  @Prop(
+    { required: false, type: String, default: () => '' },
+  ) readonly commaSeparatedColors!: string
+
+  get colors() {
+    return this.commaSeparatedColors.split(',');
+  }
 
   get numberOfColumns() {
     const numberOfColors = this.colors.length;

--- a/src/components/ShowColors.vue
+++ b/src/components/ShowColors.vue
@@ -18,6 +18,18 @@
           </code>
         </div>
       </div>
+
+      <div
+        @click="copyLinkToClipboard()"
+        class="show-colors__cell"
+      >
+        <div class="show-colors__cell-description-box">
+          <code class="show-colors__cell-description">
+            Share this palette
+            <br>
+          </code>
+        </div>
+      </div>
     </div>
     <div class="show-colors__footer">
       <router-link :to="{name: 'Home'}" class="show-colors__footer-link">Click here</router-link>
@@ -41,16 +53,20 @@ export default class ShowColors extends Vue {
   }
 
   get numberOfColumns() {
-    const numberOfColors = this.colors.length;
+    const numberOfCells = this.colors.length + 1;
 
-    const squareRoot = Math.floor(Math.sqrt(numberOfColors));
-    const isSquare = squareRoot * squareRoot === numberOfColors;
+    const squareRoot = Math.floor(Math.sqrt(numberOfCells));
+    const isSquare = squareRoot * squareRoot === numberOfCells;
 
     return isSquare ? squareRoot : squareRoot + 1;
   }
 
-  public copyToClipboard(color: string) {
-    navigator.clipboard.writeText(color);
+  public copyToClipboard(text: string) {
+    navigator.clipboard.writeText(text);
+  }
+
+  public copyLinkToClipboard() {
+    this.copyToClipboard(document.URL);
   }
 }
 </script>

--- a/src/components/ShowColors.vue
+++ b/src/components/ShowColors.vue
@@ -20,7 +20,7 @@
       </div>
     </div>
     <div class="show-colors__footer">
-      <a href="." class="show-colors__footer-link">Click here</a>
+      <router-link :to="{name: 'Home'}" class="show-colors__footer-link">Click here</router-link>
       to paste a new set of colors.
       <strong>VLAVAAV</strong> © Alex L. Alves 2020.
     </div>

--- a/src/components/ShowColors.vue
+++ b/src/components/ShowColors.vue
@@ -34,7 +34,7 @@
     <div class="show-colors__footer">
       <router-link :to="{name: 'Home'}" class="show-colors__footer-link">Click here</router-link>
       to paste a new set of colors.
-      <strong>VLAVAAV</strong> © Alex L. Alves 2020.
+      <strong>VLAVAAV</strong> © Alex L. Alves 2021.
     </div>
   </div>
 </template>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,10 @@
 import Vue from 'vue';
 import App from './App.vue';
+import router from './router';
 
 Vue.config.productionTip = false;
 
 new Vue({
+  router,
   render: h => h(App),
 }).$mount('#app');

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,0 +1,27 @@
+import Vue from 'vue';
+import VueRouter, { RouteConfig } from 'vue-router';
+import Home from '../views/Home.vue';
+
+Vue.use(VueRouter);
+
+const routes: Array<RouteConfig> = [
+  {
+    path: '/',
+    name: 'Home',
+    component: Home,
+  },
+  {
+    path: '/about',
+    name: 'About',
+    // route level code-splitting
+    // this generates a separate chunk (about.[hash].js) for this route
+    // which is lazy-loaded when the route is visited.
+    component: () => import(/* webpackChunkName: "about" */ '../views/About.vue'),
+  },
+];
+
+const router = new VueRouter({
+  routes,
+});
+
+export default router;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -13,10 +13,13 @@ const routes: Array<RouteConfig> = [
   {
     path: '/about',
     name: 'About',
-    // route level code-splitting
-    // this generates a separate chunk (about.[hash].js) for this route
-    // which is lazy-loaded when the route is visited.
-    component: () => import(/* webpackChunkName: "about" */ '../views/About.vue'),
+    component: () => import('../views/About.vue'),
+  },
+  {
+    path: '/palette/:colors',
+    name: 'Palette',
+    props: true,
+    component: () => import('../views/Palette.vue'),
   },
 ];
 

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="about">
+    <h1>This is an about page</h1>
+  </div>
+</template>

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -1,5 +1,17 @@
 <template>
   <div class="about">
-    <h1>This is an about page</h1>
+    <InitialInfo/>
   </div>
 </template>
+
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator';
+import InitialInfo from '@/components/InitialInfo.vue';
+
+@Component({
+  components: {
+    InitialInfo,
+  },
+})
+export default class App extends Vue { }
+</script>

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -11,5 +11,5 @@ import InitialInfo from '@/components/InitialInfo.vue';
     InitialInfo,
   },
 })
-export default class App extends Vue { }
+export default class About extends Vue { }
 </script>

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -1,7 +1,5 @@
 <template>
-  <div class="about">
-    <InitialInfo/>
-  </div>
+  <InitialInfo/>
 </template>
 
 <script lang="ts">

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -5,7 +5,7 @@
     </template>
     <ShowColors
       v-else
-      :colors="colors"
+      :commaSeparatedColors="colors"
     />
     <p v-if="errorMessageToShow">
       {{ errorMessageToShow }}
@@ -25,7 +25,7 @@ import ShowColors from '@/components/ShowColors.vue';
   },
 })
 export default class App extends Vue {
-  private colors: string[] = [];
+  private colors = '';
 
   private errorMessageToShow = '';
 
@@ -43,11 +43,12 @@ export default class App extends Vue {
     if (!this.colors.length) this.errorMessageToShow = 'No colors of the #RRGGBB format were found in the pasted text.';
   }
 
-  public findColors(pastedText: string): string[] {
-    const colors = pastedText.match(/#[0-9a-fA-F]{6}/g) || [];
+  public findColors(pastedText: string): string {
+    const colors = pastedText.match(/(?:#)[0-9a-fA-F]{6}/g) || [];
+
     return [...new Set(
-      colors.map(color => color.toLowerCase()),
-    )];
+      colors.map(color => color.toLowerCase().replace('#', '')),
+    )].join(',');
   }
 
   get showInitialInfo() {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="app" @paste="onAppPaste">
+  <div class="home" @paste="onAppPaste">
     <InitialInfo/>
     <p v-if="errorMessageToShow">
       {{ errorMessageToShow }}
@@ -52,7 +52,7 @@ export default class App extends Vue {
 </script>
 
 <style lang="scss">
-#app {
+.home {
   align-items: center;
   background-color: #181818;
   color: #ffffff;

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -18,7 +18,7 @@ import ShowColors from '@/components/ShowColors.vue';
     ShowColors,
   },
 })
-export default class App extends Vue {
+export default class Home extends Vue {
   private colors = '';
 
   private errorMessageToShow = '';

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,12 +1,6 @@
 <template>
   <div id="app" @paste="onAppPaste">
-    <template v-if="showInitialInfo">
-      <InitialInfo v-if="showInitialInfo"/>
-    </template>
-    <ShowColors
-      v-else
-      :commaSeparatedColors="colors"
-    />
+    <InitialInfo/>
     <p v-if="errorMessageToShow">
       {{ errorMessageToShow }}
     </p>
@@ -40,7 +34,11 @@ export default class App extends Vue {
     }
 
     this.colors = this.findColors(str);
-    if (!this.colors.length) this.errorMessageToShow = 'No colors of the #RRGGBB format were found in the pasted text.';
+    if (this.colors.length) {
+      this.$router.push({ name: 'Palette', params: { colors: this.colors } });
+    } else {
+      this.errorMessageToShow = 'No colors of the #RRGGBB format were found in the pasted text.';
+    }
   }
 
   public findColors(pastedText: string): string {
@@ -49,10 +47,6 @@ export default class App extends Vue {
     return [...new Set(
       colors.map(color => color.toLowerCase().replace('#', '')),
     )].join(',');
-  }
-
-  get showInitialInfo() {
-    return !this.colors.length;
   }
 }
 </script>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="home" @paste="onAppPaste">
+  <div @paste="onAppPaste">
     <InitialInfo/>
     <p v-if="errorMessageToShow">
       {{ errorMessageToShow }}
@@ -50,17 +50,3 @@ export default class App extends Vue {
   }
 }
 </script>
-
-<style lang="scss">
-.home {
-  align-items: center;
-  background-color: #181818;
-  color: #ffffff;
-  display: flex;
-  flex-direction: column;
-  font-family: Helvetica, Arial, sans-serif;
-  justify-content: center;
-  min-height: 100vh;
-  text-align: center;
-}
-</style>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,0 +1,71 @@
+<template>
+  <div id="app" @paste="onAppPaste">
+    <template v-if="showInitialInfo">
+      <InitialInfo v-if="showInitialInfo"/>
+    </template>
+    <ShowColors
+      v-else
+      :colors="colors"
+    />
+    <p v-if="errorMessageToShow">
+      {{ errorMessageToShow }}
+    </p>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator';
+import InitialInfo from '@/components/InitialInfo.vue';
+import ShowColors from '@/components/ShowColors.vue';
+
+@Component({
+  components: {
+    InitialInfo,
+    ShowColors,
+  },
+})
+export default class App extends Vue {
+  private colors: string[] = [];
+
+  private errorMessageToShow = '';
+
+  public onAppPaste(pastedContent: ClipboardEvent) {
+    let str = '';
+
+    if (pastedContent.clipboardData) {
+      str = pastedContent.clipboardData.getData('text');
+      this.errorMessageToShow = '';
+    } else {
+      this.errorMessageToShow = 'Clipboard is empty, nothing was pasted!';
+    }
+
+    this.colors = this.findColors(str);
+    if (!this.colors.length) this.errorMessageToShow = 'No colors of the #RRGGBB format were found in the pasted text.';
+  }
+
+  public findColors(pastedText: string): string[] {
+    const colors = pastedText.match(/#[0-9a-fA-F]{6}/g) || [];
+    return [...new Set(
+      colors.map(color => color.toLowerCase()),
+    )];
+  }
+
+  get showInitialInfo() {
+    return !this.colors.length;
+  }
+}
+</script>
+
+<style lang="scss">
+#app {
+  align-items: center;
+  background-color: #181818;
+  color: #ffffff;
+  display: flex;
+  flex-direction: column;
+  font-family: Helvetica, Arial, sans-serif;
+  justify-content: center;
+  min-height: 100vh;
+  text-align: center;
+}
+</style>

--- a/src/views/Home.vue.d.ts
+++ b/src/views/Home.vue.d.ts
@@ -1,13 +1,13 @@
 import { Vue } from 'vue-property-decorator';
 
-export default class App extends Vue {
+export default class Home extends Vue {
   private colors;
 
   private errorMessageToShow;
 
   onAppPaste(pastedContent: ClipboardEvent): void;
 
-  findColors(pastedText: string): string[];
+  findColors(pastedText: string): string;
 
   readonly showInitialInfo: boolean;
 }

--- a/src/views/Palette.vue
+++ b/src/views/Palette.vue
@@ -1,0 +1,14 @@
+<template>
+  <div class="palette">
+    Hi! {{ colors }}
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'vue-property-decorator';
+
+@Component
+export default class App extends Vue {
+  @Prop({ type: String, default: '' }) readonly colors!: string
+}
+</script>

--- a/src/views/Palette.vue
+++ b/src/views/Palette.vue
@@ -13,7 +13,7 @@ import ShowColors from '@/components/ShowColors.vue';
     ShowColors,
   },
 })
-export default class App extends Vue {
+export default class Palette extends Vue {
   @Prop({ type: String, default: '' }) readonly colors!: string
 }
 </script>

--- a/src/views/Palette.vue
+++ b/src/views/Palette.vue
@@ -1,13 +1,18 @@
 <template>
   <div class="palette">
-    Hi! {{ colors }}
+    <ShowColors :commaSeparatedColors="colors"/>
   </div>
 </template>
 
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator';
+import ShowColors from '@/components/ShowColors.vue';
 
-@Component
+@Component({
+  components: {
+    ShowColors,
+  },
+})
 export default class App extends Vue {
   @Prop({ type: String, default: '' }) readonly colors!: string
 }

--- a/tests/components/ShowColors.spec.ts
+++ b/tests/components/ShowColors.spec.ts
@@ -2,13 +2,14 @@ import { shallowMount } from '@vue/test-utils';
 import ShowColors from '@/components/ShowColors.vue';
 
 describe('InitialInfo', () => {
-  def('colors', () => ['white', 'yellow']);
+  def('colors', () => 'FFF,FF0');
 
   const wrapper = () => shallowMount(
     ShowColors, {
       propsData: {
-        colors: get('colors'),
+        commaSeparatedColors: get('colors'),
       },
+      stubs: ['router-link'],
     },
   );
 
@@ -17,23 +18,22 @@ describe('InitialInfo', () => {
   });
 
   describe('numberOfColumns', () => {
-    describe('when the number of colors is a perfect square', () => {
+    describe('when the number of colors is almost a perfect square', () => {
       def('colors', () => [
         'white', 'yellow',
-        'blue', 'green',
-      ]);
+        'blue',
+      ].join(','));
 
-      it('retuns the exact amount of columns needed', () => {
+      it('leaves space for the copy link', () => {
         expect(wrapper().vm.numberOfColumns).toEqual(2);
       });
     });
 
-    describe('when the number of colors is bigger than a perfect square', () => {
+    describe('when the number of colors is bigger than a perfect square - 1', () => {
       def('colors', () => [
         'white', 'yellow',
         'blue', 'green',
-        'orange',
-      ]);
+      ].join(','));
 
       it('retuns an extra column', () => {
         expect(wrapper().vm.numberOfColumns).toEqual(3);

--- a/tests/components/__snapshots__/InitialInfo.spec.ts.snap
+++ b/tests/components/__snapshots__/InitialInfo.spec.ts.snap
@@ -78,7 +78,7 @@ V: #ff00ff,
     <strong>
       VLAVAAV
     </strong>
-     © Alex L. Alves 2020.
+     © Alex L. Alves 2021.
     
     <br />
     

--- a/tests/components/__snapshots__/ShowColors.spec.ts.snap
+++ b/tests/components/__snapshots__/ShowColors.spec.ts.snap
@@ -8,7 +8,7 @@ exports[`InitialInfo matches snapshot 1`] = `
   >
     <div
       class="show-colors__cell"
-      style="background-color: white; flex-grow: 1;"
+      style="background-color: rgb(255, 255, 255); flex-grow: 1;"
     >
       <div
         class="show-colors__cell-description-box"
@@ -17,7 +17,7 @@ exports[`InitialInfo matches snapshot 1`] = `
           class="show-colors__cell-description"
         >
           
-          white
+          FFF
           
           <br />
         </code>
@@ -25,7 +25,7 @@ exports[`InitialInfo matches snapshot 1`] = `
     </div>
     <div
       class="show-colors__cell"
-      style="background-color: yellow; flex-grow: 1;"
+      style="background-color: rgb(255, 255, 0); flex-grow: 1;"
     >
       <div
         class="show-colors__cell-description-box"
@@ -34,7 +34,24 @@ exports[`InitialInfo matches snapshot 1`] = `
           class="show-colors__cell-description"
         >
           
-          yellow
+          FF0
+          
+          <br />
+        </code>
+      </div>
+    </div>
+     
+    <div
+      class="show-colors__cell"
+    >
+      <div
+        class="show-colors__cell-description-box"
+      >
+        <code
+          class="show-colors__cell-description"
+        >
+          
+          Share this palette
           
           <br />
         </code>
@@ -45,19 +62,19 @@ exports[`InitialInfo matches snapshot 1`] = `
   <div
     class="show-colors__footer"
   >
-    <a
+    <router-link-stub
       class="show-colors__footer-link"
-      href="."
+      to="[object Object]"
     >
       Click here
-    </a>
+    </router-link-stub>
     
     to paste a new set of colors.
     
     <strong>
       VLAVAAV
     </strong>
-     © Alex L. Alves 2020.
+     © Alex L. Alves 2021.
   
   </div>
 </div>

--- a/tests/views/Home.spec.ts
+++ b/tests/views/Home.spec.ts
@@ -1,8 +1,16 @@
 import { shallowMount } from '@vue/test-utils';
 import Home from '@/views/Home.vue';
 
+const push = jest.fn();
+
 describe('Home', () => {
-  const wrapper = () => shallowMount(Home);
+  const wrapper = () => shallowMount(Home, {
+    mocks: {
+      $router: {
+        push,
+      },
+    },
+  });
 
   it('matches snapshot', () => {
     expect(wrapper().element).toMatchSnapshot();
@@ -40,6 +48,20 @@ describe('Home', () => {
           const colors = wrapper().vm.findColors('ColorA: #FF00FF #ff00ff');
           expect(colors).toEqual('ff00ff');
         });
+      });
+    });
+  });
+
+  describe('when pasting colors', () => {
+    beforeEach(() => {
+      wrapper().vm.onAppPaste(
+        { clipboardData: { getData: () => '#ff00ff' } } as unknown as ClipboardEvent,
+      );
+    });
+
+    it('accesses the Palette view with the correct colors', () => {
+      expect(push).toBeCalledWith({
+        name: 'Palette', params: { colors: 'ff00ff' },
       });
     });
   });

--- a/tests/views/Home.spec.ts
+++ b/tests/views/Home.spec.ts
@@ -1,45 +1,44 @@
 import { shallowMount } from '@vue/test-utils';
-import App from '@/App.vue';
+import Home from '@/views/Home.vue';
 
-describe('App', () => {
-  def('wrapper', () => shallowMount(App));
-  const wrapper = shallowMount(App);
+describe('Home', () => {
+  const wrapper = () => shallowMount(Home);
 
   it('matches snapshot', () => {
-    expect(wrapper.element).toMatchSnapshot();
+    expect(wrapper().element).toMatchSnapshot();
   });
 
   describe('findColors', () => {
     describe('when text with no color is passed', () => {
       it('returns an empty list', () => {
         expect(
-          wrapper.vm.findColors('Color: white :('),
-        ).toEqual([]);
+          wrapper().vm.findColors('Color: white :('),
+        ).toEqual('');
       });
     });
 
     describe('when an uppercase color is passed', () => {
       it('returns that color', () => {
         expect(
-          wrapper.vm.findColors('Color: #FF00FF'),
-        ).toContain('#ff00ff');
+          wrapper().vm.findColors('Color: #FF00FF'),
+        ).toMatch('ff00ff');
       });
     });
 
     describe('when more than one color is passed', () => {
       describe('when they are unique', () => {
         it('returns those colors', () => {
-          const colors = wrapper.vm.findColors('ColorA: #FF00FF #abcde0');
+          const colors = wrapper().vm.findColors('ColorA: #FF00FF #abcde0');
 
-          expect(colors).toContain('#ff00ff');
-          expect(colors).toContain('#abcde0');
+          expect(colors).toMatch('ff00ff');
+          expect(colors).toMatch('abcde0');
         });
       });
 
       describe('when they are duplicated', () => {
         it('returns those colors', () => {
-          const colors = wrapper.vm.findColors('ColorA: #FF00FF #ff00ff');
-          expect(colors).toEqual(['#ff00ff']);
+          const colors = wrapper().vm.findColors('ColorA: #FF00FF #ff00ff');
+          expect(colors).toEqual('ff00ff');
         });
       });
     });

--- a/tests/views/__snapshots__/Home.spec.ts.snap
+++ b/tests/views/__snapshots__/Home.spec.ts.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`App matches snapshot 1`] = `
-<div
-  id="app"
->
+exports[`Home matches snapshot 1`] = `
+<div>
   <initialinfo-stub />
    
   <!---->


### PR DESCRIPTION
* Added router to project
* Created /Palette/:colors
* Created /About (to be supplemented later)
* Moved main page logic from App to Home view
* ShowColors now accepts a string of comma separated colors (`'FF0,F0F'` instead of `['FF0', 'F0F']`)
* Added clickable cell for sharing
* Updated year to 2021
* Update specs